### PR TITLE
Fix build on ARM64

### DIFF
--- a/geph4-binder/src/bindercore.rs
+++ b/geph4-binder/src/bindercore.rs
@@ -529,7 +529,7 @@ fn verify_libsodium_password(password: &str, hash: &str) -> bool {
     let res = unsafe {
         libsodium_sys::crypto_pwhash_str_verify(
             hash.as_ptr(),
-            password.as_ptr() as *const i8,
+            password.as_ptr() as *const u8,
             password.len() as u64,
         )
     };
@@ -541,14 +541,14 @@ fn hash_libsodium_password(password: &str) -> String {
     let mut output = vec![0u8; 1024];
     let res = unsafe {
         libsodium_sys::crypto_pwhash_str(
-            output.as_mut_ptr() as *mut i8,
-            password.as_ptr() as *const i8,
+            output.as_mut_ptr() as *mut u8,
+            password.as_ptr() as *const u8,
             password.len() as u64,
             libsodium_sys::crypto_pwhash_OPSLIMIT_INTERACTIVE as u64,
             libsodium_sys::crypto_pwhash_MEMLIMIT_INTERACTIVE as usize,
         )
     };
     assert_eq!(res, 0);
-    let cstr = unsafe { CStr::from_ptr(output.as_ptr() as *const i8) };
+    let cstr = unsafe { CStr::from_ptr(output.as_ptr() as *const u8) };
     cstr.to_str().unwrap().to_owned()
 }


### PR DESCRIPTION
Following errors were encountered when installing with `yay -Syu geph4-client geph4-vpn-helper` on ESPRESSObin:
```
   Compiling geph4-binder v0.1.0 (/home/alarm/.cache/yay/geph4/src/geph4-4.4.4/geph4-binder)
error[E0308]: mismatched types
   --> geph4-binder/src/bindercore.rs:532:13
    |
532 |             password.as_ptr() as *const i8,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`

error[E0308]: mismatched types
   --> geph4-binder/src/bindercore.rs:544:13
    |
544 |             output.as_mut_ptr() as *mut i8,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*mut u8`
               found raw pointer `*mut i8`

error[E0308]: mismatched types
   --> geph4-binder/src/bindercore.rs:545:13
    |
545 |             password.as_ptr() as *const i8,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`

error[E0308]: mismatched types
   --> geph4-binder/src/bindercore.rs:552:40
    |
552 |     let cstr = unsafe { CStr::from_ptr(output.as_ptr() as *const i8) };
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`

error: aborting due to 4 previous errors

For more information about this error, try `rustc --explain E0308`.
error: could not compile `geph4-binder`

To learn more, run the command again with --verbose.
```

Using rustc 1.53.0.