### PR TITLE
绕过内部网络的流量，避免误代理局域网流量

### DIFF
--- a/geph4-client/src/main.rs
+++ b/geph4-client/src/main.rs
@@ -1,4 +1,5 @@
 #![type_length_limit = "2000000"]
+#![feature(ip)]
 
 use std::{collections::BTreeMap, io::Write, path::PathBuf, sync::Arc, time::Duration};
 


### PR DESCRIPTION
这个 PR 将 geph4-client 里的 main_connect.rs 中的 handle_socks5 函数的逻辑修改了一下，增加默认绕过非公网 IP 的逻辑。避免那些无法从 exit server 访问的内网流量被误发送到 exit server